### PR TITLE
 [TECH] Update ACL provisioning for new AWS defaults

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls
   bucket = aws_s3_bucket.encrypted_bucket.id
 
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "ObjectWriter"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -51,8 +51,6 @@ data "template_file" "encrypted_bucket_policy" {
 resource "aws_s3_bucket" "encrypted_bucket" {
   bucket = var.bucket_name
 
-  acl = var.acl
-
   force_destroy = local.allow_destroy_when_objects_present
 
   server_side_encryption_configuration {
@@ -81,6 +79,21 @@ resource "aws_s3_bucket" "encrypted_bucket" {
   tags = merge({
     Name = var.bucket_name
   }, var.tags)
+}
+
+resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.encrypted_bucket
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "encrypted_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.encrypted_bucket_ownership_controls]
+
+  bucket = aws_s3_bucket.encrypted_bucket
+  acl = var.acl
 }
 
 data "aws_iam_policy_document" "encrypted_bucket_policy_document" {

--- a/main.tf
+++ b/main.tf
@@ -97,8 +97,8 @@ resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
   bucket = aws_s3_bucket.encrypted_bucket.id
 
  versioning_configuration {
-   status = local.enable_versioning
-   mfa_delete = local.enable_mfa_delete
+   status = local.enable_versioning ? "Enabled" : "Disabled"
+   mfa_delete = local.enable_mfa_delete ? "Enabled" : "Disabled"
  }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -53,16 +53,6 @@ resource "aws_s3_bucket" "encrypted_bucket" {
 
   force_destroy = local.allow_destroy_when_objects_present
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = local.kms_master_key_id
-        sse_algorithm     = local.sse_algorithm
-      }
-      bucket_key_enabled = local.enable_bucket_key
-    }
-  }
-
   dynamic logging {
     for_each = local.enable_access_logging ? toset(["logging"]) : toset([])
     content {
@@ -79,6 +69,18 @@ resource "aws_s3_bucket" "encrypted_bucket" {
   tags = merge({
     Name = var.bucket_name
   }, var.tags)
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_server_side_encryption_configuration" {
+  bucket = aws_s3_bucket.encrypted_bucket
+
+  rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = local.kms_master_key_id
+        sse_algorithm     = local.sse_algorithm
+      }
+      bucket_key_enabled = local.enable_bucket_key
+    }
 }
 
 resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls" {

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_s3_bucket" "encrypted_bucket" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_server_side_encryption_configuration" {
-  bucket = aws_s3_bucket.encrypted_bucket
+  bucket = aws_s3_bucket.encrypted_bucket.id
 
   rule {
       apply_server_side_encryption_by_default {
@@ -84,7 +84,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_
 }
 
 resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls" {
-  bucket = aws_s3_bucket.encrypted_bucket
+  bucket = aws_s3_bucket.encrypted_bucket.id
 
   rule {
     object_ownership = "BucketOwnerPreferred"
@@ -94,7 +94,7 @@ resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls
 resource "aws_s3_bucket_acl" "encrypted_bucket_acl" {
   depends_on = [aws_s3_bucket_ownership_controls.encrypted_bucket_ownership_controls]
 
-  bucket = aws_s3_bucket.encrypted_bucket
+  bucket = aws_s3_bucket.encrypted_bucket.id
   acl = var.acl
 }
 

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,15 @@ resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
  }
 }
 
+resource "aws_s3_bucket_public_access_block" "encrypted_bucket_public_access_block" {
+  bucket = aws_s3_bucket.encrypted_bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
 data "aws_iam_policy_document" "encrypted_bucket_policy_document" {
   source_json   = var.source_policy_json
   override_json = data.template_file.encrypted_bucket_policy.rendered

--- a/main.tf
+++ b/main.tf
@@ -79,14 +79,6 @@ resource "aws_s3_bucket_ownership_controls" "encrypted_bucket_ownership_controls
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block" {
-  count = (
-  var.public_access_block.block_public_acls
-  || var.public_access_block.block_public_policy
-  || var.public_access_block.ignore_public_acls
-  || var.public_access_block.restrict_public_buckets
-  ? 1 : 0
-  )
-
   bucket = aws_s3_bucket.encrypted_bucket.id
 
   block_public_acls       = var.public_access_block.block_public_acls

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   sse_s3_algorithm  = "AES256"
   sse_kms_algorithm = "aws:kms"
 
-  sse_algorithm     = var.kms_key_arn == "" ? local.sse_s3_algorithm : local.sse_kms_algorithm
+  sse_algorithm     = var.kms_key_arn == null ? local.sse_s3_algorithm : local.sse_kms_algorithm
   kms_master_key_id = var.kms_key_arn == "" ? null : var.kms_key_arn
 
   enable_versioning                  = var.enable_versioning == "yes" ? "Enabled" : "Disabled"

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_
   rule {
       apply_server_side_encryption_by_default {
         kms_master_key_id = local.kms_master_key_id
-        sse_algorithm     = local.sse_algorithm
+        sse_algorithm     = local.sse_kms_algorithm
       }
       bucket_key_enabled = local.enable_bucket_key
     }

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
   sse_algorithm     = var.kms_key_arn == "" ? local.sse_s3_algorithm : local.sse_kms_algorithm
   kms_master_key_id = var.kms_key_arn == "" ? null : var.kms_key_arn
 
-  enable_versioning                  = var.enable_versioning == "yes"
-  enable_mfa_delete                  = var.enable_mfa_delete == "" ? var.mfa_delete == "true" : var.enable_mfa_delete == "yes"
+  enable_versioning                  = var.enable_versioning == "yes" ? "Enabled" : "Disabled"
+  enable_mfa_delete                  = (var.enable_mfa_delete == "" ? var.mfa_delete == "true" : var.enable_mfa_delete == "yes") ? "Enabled" : "Disabled"
   enable_access_logging              = var.enable_access_logging == "yes"
   enable_bucket_key                 = var.enable_bucket_key == "yes"
   allow_destroy_when_objects_present = var.allow_destroy_when_objects_present == "yes"
@@ -97,8 +97,8 @@ resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
   bucket = aws_s3_bucket.encrypted_bucket.id
 
  versioning_configuration {
-   status = local.enable_versioning ? "Enabled" : "Disabled"
-   mfa_delete = local.enable_mfa_delete ? "Enabled" : "Disabled"
+   status = local.enable_versioning
+   mfa_delete = local.enable_mfa_delete
  }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -53,19 +53,6 @@ resource "aws_s3_bucket" "encrypted_bucket" {
 
   force_destroy = local.allow_destroy_when_objects_present
 
-  dynamic logging {
-    for_each = local.enable_access_logging ? toset(["logging"]) : toset([])
-    content {
-      target_bucket = var.access_log_bucket_name
-      target_prefix = var.access_log_object_key_prefix
-    }
-  }
-
-  versioning {
-    enabled    = local.enable_versioning
-    mfa_delete = local.enable_mfa_delete
-  }
-
   tags = merge({
     Name = var.bucket_name
   }, var.tags)
@@ -96,6 +83,23 @@ resource "aws_s3_bucket_acl" "encrypted_bucket_acl" {
 
   bucket = aws_s3_bucket.encrypted_bucket.id
   acl = var.acl
+}
+
+resource "aws_s3_bucket_logging" "encrypted_bucket_logging" {
+  bucket = aws_s3_bucket.encrypted_bucket.id
+
+  for_each = local.enable_access_logging ? toset(["logging"]) : toset([])
+  target_bucket = var.access_log_bucket_name
+  target_prefix = var.access_log_object_key_prefix
+}
+
+resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
+  bucket = aws_s3_bucket.encrypted_bucket.id
+
+ versioning_configuration {
+   status = local.enable_versioning
+   mfa_delete = local.enable_mfa_delete
+ }
 }
 
 data "aws_iam_policy_document" "encrypted_bucket_policy_document" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,10 +36,6 @@ variable "access_log_bucket_name" {
   description = "The name of the bucket to use for access logging, required when enable_access_logging is \"yes\"."
   type = string
   default = ""
-  validation {
-    condition = var.enable_access_logging == "yes" ? length(var.access_log_bucket_name) > 0 : true
-    error_message = "You must provide an access_log_bucket_name if enable_access_logging is 'yes'"
-  }
 }
 
 variable "access_log_object_key_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,9 @@ variable "access_log_bucket_name" {
   description = "The name of the bucket to use for access logging, required when enable_access_logging is \"yes\"."
   type = string
   default = ""
+  validation {
+    condition = var.enable_access_logging == "yes" ? length(var.access_log_bucket_name) > 0 : true
+  }
 }
 
 variable "access_log_object_key_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,7 @@ variable "access_log_bucket_name" {
   default = ""
   validation {
     condition = var.enable_access_logging == "yes" ? length(var.access_log_bucket_name) > 0 : true
+    error_message = "You must provide an access_log_bucket_name if enable_access_logging is 'yes'"
   }
 }
 


### PR DESCRIPTION
In April 2023, Amazon change defaults for AWS S3 buckets, disabling ACLs and enabling public access blocks by default. You can read more about it here: [Amazon S3 will automatically enable S3 Block Public Access and disable access control lists for all new buckets starting in April 2023](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/)

While I was at it I moved some of the config from deprecated blocks in the S3 bucket to their own resources.